### PR TITLE
Changed the Newtonsoft.Json reference

### DIFF
--- a/Har/Har.csproj
+++ b/Har/Har.csproj
@@ -40,7 +40,8 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>      
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Changed the reference of Newtonsoft.Json to be for a non-specific version in order to avoid collision with other dll files who uses a newer version